### PR TITLE
fix for matplotlib >=3

### DIFF
--- a/QCUnif_wadwrapper.py
+++ b/QCUnif_wadwrapper.py
@@ -11,23 +11,23 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# PyWAD is open-source software and consists of a set of plugins written in python for the WAD-Software medical physics quality control software. 
-# The WAD Software can be found on https://github.com/wadqc
-# 
-# The pywad package includes plugins for the automated analysis of QC images for various imaging modalities. 
-# PyWAD has been originaly initiated by Dennis Dickerscheid (AZN), Arnold Schilham (UMCU), Rob van Rooij (UMCU) and Tim de Wit (AMC) 
+#
+# This code is an analysis module for WAD-QC 2.0: a server for automated 
+# analysis of medical images for quality control.
+#
+# The WAD-QC Software can be found on 
+# https://bitbucket.org/MedPhysNL/wadqc/wiki/Home
 #
 #
 # Changelog:
-#
+#   20190426: Fix for matplotlib>3
 #
 # Description of this plugin:
 # This plugin calculates the NEMA differential and integral uniformity of an image 
 #
 
 
-__version__ = '20180714'
+__version__ = '20190426'
 __author__ = 'DD, tdw'
 
 
@@ -44,8 +44,15 @@ import getopt
 import numpy as np
 from numpy import random as rnd
 
-import tempfile
-os.environ['MPLCONFIGDIR'] = tempfile.mkdtemp()
+if not 'MPLCONFIGDIR' in os.environ:
+    import pkg_resources
+    try:
+        #only for matplotlib < 3 should we use the tmp work around, but it should be applied before importing matplotlib
+        matplotlib_version = [int(v) for v in pkg_resources.get_distribution("matplotlib").version.split('.')]
+        if matplotlib_version[0]<3:
+            os.environ['MPLCONFIGDIR'] = "/tmp/.matplotlib" # if this folder already exists it must be accessible by the owner of WAD_Processor 
+    except:
+        os.environ['MPLCONFIGDIR'] = "/tmp/.matplotlib" # if this folder already exists it must be accessible by the owner of WAD_Processor 
 
 import matplotlib
 matplotlib.use('Agg')


### PR DESCRIPTION
WAD-QC 2.0.6 uses matplotlib 3.x, which has a different logic for handling the font cache.